### PR TITLE
#3: Fix issue with payload lifecycle hook and hook

### DIFF
--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -113,7 +113,7 @@ describe('Verifying a Slack request', () => {
       url: '/slack',
       headers: {
         'x-slack-request-timestamp': timestamp,
-        'x-slack-signature': signature,
+        'x-slack-signature': `v1=${signature}`,
         'content-type': 'application/x-www-form-urlencoded'
       },
       payload: Buffer.from(getPayload(positiveTestCaseToken))
@@ -144,10 +144,9 @@ describe('Verifying a Slack request', () => {
       }
     });
 
-    // https://github.com/hapijs/hapi/issues/3736
-    // we actually want this code but it throws an error for some reason with server.inject
-    // expect(res.statusCode).toBe(401);
-    // expect(res.result.message).toBe('Payload failed authentication');
+    const res = await server.inject(slackRequest);
+    expect(res.statusCode).toBe(401);
+    expect(res.result.message).toBe('Payload failed authentication');
 
     try {
       await server.inject(slackRequest);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -38,8 +38,7 @@ const HapiSlackSignature = (server, options): Hapi.ServerAuthSchemeObject => ({
     if (crypto.timingSafeEqual(Buffer.from(signature, 'hex'), Buffer.from(hash, 'hex'))) {
       return h.continue;
     } else {
-      h.unauthenticated(Boom.unauthorized('Payload failed authentication'));
-      return null;
+      return Boom.unauthorized('Payload failed authentication');
     }
   }
 });


### PR DESCRIPTION
This fixes #3.  There are a couple of problems

1) The slackSignature in test is being set incorrectly.  It's being parsed as `${version}=${signature}` but it was being set as just a hex value with no version
2) `h` actually does not have the unauthenticated method.  The proper way to reject authentication at this point is to return an error

> A lifecycle method to authenticate the request payload. When the scheme payload() method returns an error with a message, it means payload validation failed due to bad payload. If the error has no message but includes a scheme name (e.g. Boom.unauthorized(null, 'Custom')), authentication may still be successful if the route auth.payload configuration is set to 'optional'.
